### PR TITLE
Add handler for /prometheus and /grafana on default server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     image: grafana/grafana:latest
     container_name: arcam_grafana
     restart: unless-stopped
+    environment:
+      - GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s/grafana/
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,6 +25,28 @@ http {
         proxy_buffering off;
         proxy_cache off;
         server_name _;
+
+        location /prometheus/ {
+            resolver 127.0.0.11 valid=15s;
+
+            proxy_set_header   Host $host;
+            set $upstream http://arcam_prometheus:9090;
+            proxy_pass $upstream;
+
+            rewrite ^/prometheus/?$ /prometheus/graph redirect;
+            rewrite ^/prometheus(.*)$ $1 break;
+        }
+
+        location /grafana/ {
+            resolver 127.0.0.11 valid=15s;
+
+            proxy_set_header   Host $host;
+            set $upstream http://arcam_grafana:3000;
+            proxy_pass $upstream;
+
+            rewrite ^/grafana(.*)$ $1 break;
+        }
+
         location / {
             proxy_pass http://webserver;
         }


### PR DESCRIPTION
Now, when we visit `localhost/prometheus` and `localhost/grafana` we reach the UI for both containers respectively. Nginx ftw