### PR TITLE
Incorporate DeviceMetric enums into API endpoints for updating state

### DIFF
--- a/server/arcam_metrics_handler.py
+++ b/server/arcam_metrics_handler.py
@@ -3,6 +3,8 @@ from prometheus_client import Gauge
 from prometheus_client import generate_latest
 from prometheus_client import Histogram
 
+from constants import DeviceMetric
+
 class ArcamMetricsHandler:
   def initialize(self):
     self.health_check_latency_seconds = Histogram(
@@ -32,6 +34,20 @@ class ArcamMetricsHandler:
       'Value of the Arcam power state, 0 for off and 1 for on',
     )
 
+  def maybe_update_gauge_with_enum(self, metric_enum, value):
+    maybe_result = {
+      DeviceMetric.MUTE: self.mute_state,
+      DeviceMetric.POWER: self.power_state,
+      DeviceMetric.VOLUME: self.volume_state,
+    }.get(metric_enum)
+
+    # if the given enum doesn't contain an entry in the above map
+    # do nothing. hence the "maybe" in this function's name
+    if maybe_result is None:
+      return
+    # prometheus gauges only take integers as values so we cast
+    # whatever we are given to an int
+    maybe_result.set(int(value))
 
   def generate_latest(self):
     return generate_latest()

--- a/server/constants.py
+++ b/server/constants.py
@@ -2,7 +2,12 @@ import enum
 
 
 class DeviceMetric(enum.Enum):
-  MUTE = enum.auto() 
-  POWER = enum.auto() 
-  VOLUME = enum.auto() 
-  SOURCE = enum.auto()
+  MUTE = ("mute", lambda x: bool(int(x)))
+  POWER = ("power", lambda x: bool(int(x)))
+  VOLUME = ("volume", lambda x: int(x), lambda x: x >= 0 and x <= 99)
+  SOURCE = ("source", lambda x: str(x))
+
+  def __init__(self, designation, cast_to_correct_type, is_valid=lambda x: True):
+    self.designation = designation
+    self.cast_to_correct_type = cast_to_correct_type
+    self.is_valid = is_valid

--- a/website/src/App.svelte
+++ b/website/src/App.svelte
@@ -29,7 +29,7 @@
 
   async function sendRequestToArcam(endpoint, value) {
     const url = new URL(
-      `./api/${endpoint}?value=${value}`, window.location.href
+      `./api/set/${endpoint}?value=${value}`, window.location.href
     );
     await fetch(url.href, {method: 'POST'});
   }


### PR DESCRIPTION
Cleans up code in server.py and puts all endpoints for updating state behind a `/set/` prefix.